### PR TITLE
Update README.md

### DIFF
--- a/Plugins/BTCPayServer.Plugins.JumpSeller/README.md
+++ b/Plugins/BTCPayServer.Plugins.JumpSeller/README.md
@@ -16,12 +16,12 @@ Accept Bitcoin and Lightning Network payments directly in your JumpSeller store.
 5. Go to Settings → Checkout → Payments. On the top right of the page , click on `Add Payment Method` button
 6. You'd see a list of Methods to select from. Choose `External Gateway`.
 7. Fill in the details of the payment method as follows:
-   - Name: `BTCPay Server` (or any name you want to give to the payment method)
+   - Name: `Bitcoin (via BTCPay)` (or any name you want to give to the payment method)
    - Description: `Pay with Bitcoin and Lightning Network`
 	- Logo: BTCPay Server logo
 	- Payment Method URL: This is the gateway url and it is available in the plugin settings page.
-	- Payment Method Key: This can be any value, for example `btcpayserver`. The value chosen should also be added in the plugin settings page for XXXX input field.
-	- Payment Method Secret: This can be any value, for example `btcpayserver`. The value chosen should also be added in the plugin settings page for YYYY input field.
+	- Payment Method Key: This can be any value, for example `btcpayserver`. The value chosen should also be added in the plugin settings page.
+	- Payment Method Secret: This can be any value, for example `btcpayserver`. The value chosen should also be added in the plugin settings page. 
 8. Click `Save` to save the payment method. You should see the new payment method in the list of payment methods. Also save settings in the plugin page after adding the payment method in JumpSeller.
 
 That's it. Now you can now receive Bitcoin and Lightning Network payments in your JumpSeller store.


### PR DESCRIPTION
Removed the placeholders, I think it is clear for people that the fields are named 1:1 on jumpseller and plugin side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated payment method name from "BTCPay Server" to "Bitcoin (via BTCPay)".
  * Refined Payment Method Key/Secret guidance with clearer, more generic setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->