### PR TITLE
Refactor event queries to return all events regardless of state. 

### DIFF
--- a/Plugins/BTCPayServer.Plugins.SatoshiTickets/Controllers/GreenfieldSatoshiTicketsEventsController.cs
+++ b/Plugins/BTCPayServer.Plugins.SatoshiTickets/Controllers/GreenfieldSatoshiTicketsEventsController.cs
@@ -50,7 +50,7 @@ public class GreenfieldSatoshiTicketsEventsController : ControllerBase
     {
         await using var ctx = _dbContextFactory.CreateContext();
 
-        var eventsQuery = ctx.Events.Where(c => c.StoreId == CurrentStoreId && c.EventState == Data.EntityState.Active);
+        var eventsQuery = ctx.Events.Where(c => c.StoreId == CurrentStoreId);
         if (expired)
             eventsQuery = eventsQuery.Where(e => e.StartDate <= DateTime.UtcNow);
 
@@ -75,7 +75,7 @@ public class GreenfieldSatoshiTicketsEventsController : ControllerBase
     {
         await using var ctx = _dbContextFactory.CreateContext();
 
-        var entity = ctx.Events.FirstOrDefault(c => c.Id == eventId && c.StoreId == CurrentStoreId && c.EventState == Data.EntityState.Active);
+        var entity = ctx.Events.FirstOrDefault(c => c.Id == eventId && c.StoreId == CurrentStoreId);
         if (entity == null)
             return EventNotFound();
 

--- a/Plugins/BTCPayServer.Plugins.SatoshiTickets/Resources/swagger.json
+++ b/Plugins/BTCPayServer.Plugins.SatoshiTickets/Resources/swagger.json
@@ -52,7 +52,7 @@
       "get": {
         "tags": ["Events"],
         "summary": "List events",
-        "description": "Returns active events for the store. Use `expired=true` to get only past events.",
+        "description": "Returns all events for the store (active and disabled). Use `expired=true` to get only past events.",
         "operationId": "getEvents",
         "parameters": [
           {
@@ -127,7 +127,7 @@
       "get": {
         "tags": ["Events"],
         "summary": "Get event",
-        "description": "Returns a single active event by ID.",
+        "description": "Returns a single event by ID (active or disabled).",
         "operationId": "getEvent",
         "parameters": [
           {


### PR DESCRIPTION
I just realized we need to return all states, not just the "active" ones. 

**Summary**
Events API endpoints now also return disabled events. Previously only active events were returned.

**Changes**
GET /api/v1/stores/{storeId}/satoshi-tickets/events – returns all events (active and disabled)
GET /api/v1/stores/{storeId}/satoshi-tickets/events/{eventId} – returns a single event by ID, including when it is disabled

**Implementation**
Removed filtering by EventState == Active in GreenfieldSatoshiTicketsEventsController.cs
Updated endpoint descriptions in swagger.json

**Motivation**
Integrations (e.g. WooCommerce) need to list all events, including disabled ones, for:
Event selection in settings
Showing existing events in dropdowns
Ticket fulfillment for offline payments
Each event includes eventState ("Active" or "Disabled"), so clients can filter if needed.

**Breaking changes**
None. The API response format is unchanged, with additional disabled events included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event API endpoints now retrieve all events (active and disabled) instead of only active events.

* **Documentation**
  * Updated API documentation to reflect that event endpoints return both active and disabled events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->